### PR TITLE
State machine visualisation

### DIFF
--- a/common/scripts/visualise_sm.py
+++ b/common/scripts/visualise_sm.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+
+import argparse
+import networkx as nx
+import matplotlib.pyplot as plt
+
+from mas_execution.sm_loader import SMLoader
+
+if __name__ == '__main__':
+    argparser = argparse.ArgumentParser()
+    argparser.add_argument('-sm', '--sm_path', type=str, required=True,
+                           help='Path to a state machine definition file')
+
+    args = argparser.parse_args()
+    sm_data = SMLoader.load_sm(args.sm_path)
+
+    graph = nx.DiGraph()
+    for _, state in sm_data.state_params.items():
+        for transition, resulting_state in state.transitions.items():
+            graph.add_edge(state.name, resulting_state)
+
+    init_state = list(sm_data.state_params.keys())[0]
+    sink_nodes = [node for node in graph.nodes
+                  if graph.out_degree(node) == 0]
+
+    node_positions = nx.planar_layout(graph)
+    nx.draw(graph, node_positions, with_labels=True)
+    nx.draw_networkx_nodes(graph, node_positions, nodelist=[init_state], node_color='g')
+    nx.draw_networkx_nodes(graph, node_positions, nodelist=sink_nodes, node_color='r')
+    plt.show()


### PR DESCRIPTION
### Summary

Resolves https://github.com/b-it-bots/mas_execution_manager/issues/9

The PR adds a simple networkx-based script for visualising a state machine. The script takes a single argument - the path to a state machine definition file. An example call would be 

```
python3 visualise_sm.py -sm /path/to/my/sm.yaml
```

The plot shows the states of the state machines and the transitions between them as directed arrows. As per the last comment in the issue discussion, the script uses different colours for plotting the initial state, terminal states, and all other states (green, red, and blue respectively).

### Examples

The following are some example plots generated by the script.
* The following is the state machine of the lab manager scenario introduced in https://github.com/b-it-bots/mas_domestic_robotics/pull/233:
![lab_manager_sm](https://user-images.githubusercontent.com/2042490/90537002-15bb9d00-e17d-11ea-9055-7e6b787d0b62.png)
* The state machine of the person registration task added in https://github.com/b-it-bots/mas_domestic_robotics/pull/235 is shown below:
![register_person_sm](https://user-images.githubusercontent.com/2042490/90537017-1bb17e00-e17d-11ea-91f6-1c143e29a1f4.png)
